### PR TITLE
Receive Only Channels + Different Zone/Channel Announce Text vs. Display Text

### DIFF
--- a/client/ui/index.html
+++ b/client/ui/index.html
@@ -107,6 +107,6 @@
     <script src="js/ScanManager.js"></script>
     <script src="js/script.js"></script>
     <script src="js/ui.js"></script>
-    <!-- <script src="https://code.responsivevoice.org/responsivevoice.js?key=PekkZld1"></script> -->
+    <script src="https://code.responsivevoice.org/responsivevoice.js?key=PekkZld1"></script>
 </body>
 </html>

--- a/client/ui/js/script.js
+++ b/client/ui/js/script.js
@@ -658,9 +658,27 @@ async function powerOn(reReg) {
             await displayBootScreen(bootScreenMessages);
         }
 
-        if (!isScannerModel()) {
-            responsiveVoice.speak(`${currentZone.name_announce}`, `US English Female`, {rate: .8});
-            responsiveVoice.speak(`${currentChannel.name_announce}`, `US English Female`, {rate: .8});
+        if (!isScannerModel() && currentCodeplug.isAnnounceZoneChannelTalkgroups === true) {
+            fetch('/configs/config.yml')
+              .then(response => response.text())
+              .then(yamlText => {
+                const lines = yamlText.split('\n');
+                for (const line of lines) {
+                  const matchApiKey = line.match(/^\s*responsiveVoiceApiKey\s*:\s+\S*$/i);
+                  const apiKey = matchApiKey.replace("responsiveVoiceApiKey: ", "")
+                  if (apiKey !== null && apiKey !== "") {
+                    responsiveVoice.speak(`${currentZone.name_announce}`, `US English Female`, {rate: .8});
+                    responsiveVoice.speak(`${currentChannel.name_announce}`, `US English Female`, {rate: .8});
+                    return;
+                  } else {
+                      console.error('responsiveVoiceApiKey not set in config.yml);
+                      return;
+                  }
+                }
+              })
+              .catch(err => {
+                console.warn('Could not load config.yml, defaulting to disabled zone/channel announcements:', err);
+              });
         }
 
         updateDisplay();

--- a/client/ui/js/script.js
+++ b/client/ui/js/script.js
@@ -102,19 +102,20 @@ function socketOpen() {
 }
 
 let beepVolumeReduction = 0.6; // default value
+let isResponsiveVoiceApiKeySet = false; // default value
 fetch('/configs/config.yml')
   .then(response => response.text())
   .then(yamlText => {
     const lines = yamlText.split('\n');
     for (const line of lines) {
       const matchBeepVolume = line.match(/^\s*beepVolumeReduction\s*:\s*([0-9.]+)\s*$/i);
+      const matchApiKeyValue = line.match(/^\s*responsiveVoiceApiKey\s*:\s+\S*$/i);
       if (matchBeepVolume) {
         let parsed = parseFloat(matchBeepVolume[1]);
         if (isNaN(parsed)) {
           console.error('beepVolumeReduction in config.yml is not a number. Using default value.');
           return;
-        }
-        if (parsed < 0.0) {
+        } if (parsed < 0.0) {
           console.error('beepVolumeReduction in config.yml is less than 0. Clamping to 0.');
           beepVolumeReduction = 0.0;
         } else if (parsed > 1.0) {
@@ -124,31 +125,19 @@ fetch('/configs/config.yml')
           beepVolumeReduction = parsed;
         }
       }
-    }
-  })
-  .catch(err => {
-    console.warn('Could not load config.yml, using default config values:', err);
-  });
-
-let isResponsiveVoiceApiKeySet = false; // default value
-fetch('/configs/config.yml')
-  .then(response => response.text())
-  .then(yamlText => {
-    const lines = yamlText.split('\n');
-    for (const line of lines) {
-      const matchApiKeyValue = line.match(/^\s*responsiveVoiceApiKey\s*:\s+\S*$/i);
-      const apiKey = matchApiKeyValue.replace("responsiveVoiceApiKey: ", "");
-      if (apiKey !== null && apiKey !== "") {
-        isResponsiveVoiceApiKeySet = true
-        console.log('Responsive voice enabled);
+      if (matchApiKeyValue) {
+        let apiKey = matchApiKeyValue.replace("responsiveVoiceApiKey: ", "");
+        if (apiKey !== null && apiKey !== "") {
+          isResponsiveVoiceApiKeySet = true
+          console.log('Responsive voice enabled')
         } else {
-          console.log('Responsive voice API key not set, disabled);
+          console.log('Responsive voice API key not set, disabled')
         }
       }
     }
   })
   .catch(err => {
-    console.warn('Could not load config.yml, defaulting to disbaled responsive voice:', err);
+    console.warn('Could not load config.yml, using default config values:', err);
   });
 
 
@@ -671,9 +660,9 @@ async function powerOn(reReg) {
             bootImage.style.display = 'none';
         } else {
             const bootScreenMessages = [
-                {text: "", duration: 0, line: "line1"},
-                {text: "", duration: 0, line: "line3"},
-                {text: HOST_VERSION, duration: 1500, line: "line2"},
+                {text: "", duration: 0, : "line1"},
+                {text: "", duration: 0, : "line3"},
+                {text: HOST_VERSION, duration: 1500, : "line2"},
                 {text: radioModel, duration: 1500, line: "line2"}
             ];
 

--- a/client/ui/js/script.js
+++ b/client/ui/js/script.js
@@ -956,8 +956,8 @@ function changeZone(direction) {
     const currentZone = currentCodeplug.zones[currentZoneIndex];
     const currentChannel = currentZone.channels[currentChannelIndex];
 
-    // responsiveVoice.speak(`${currentZone.name}`, `US English Female`, {rate: .8});
-    // responsiveVoice.speak(`${currentChannel.name}`, `US English Female`, {rate: .8});
+    responsiveVoice.speak(`${currentZone.name_announce}`, `US English Female`, {rate: .8});
+    responsiveVoice.speak(`${currentChannel.name_announce}`, `US English Female`, {rate: .8});
     SendGroupAffiliationRemoval(currentTg);
 
     updateDisplay();

--- a/client/ui/js/script.js
+++ b/client/ui/js/script.js
@@ -659,8 +659,8 @@ async function powerOn(reReg) {
         }
 
         if (!isScannerModel()) {
-            // responsiveVoice.speak(`${currentZone.name}`, `US English Female`, {rate: .8});
-            // responsiveVoice.speak(`${currentChannel.name}`, `US English Female`, {rate: .8});
+            responsiveVoice.speak(`${currentZone.name_announce}`, `US English Female`, {rate: .8});
+            responsiveVoice.speak(`${currentChannel.name_announce}`, `US English Female`, {rate: .8});
         }
 
         updateDisplay();

--- a/client/ui/js/script.js
+++ b/client/ui/js/script.js
@@ -928,9 +928,10 @@ function changeChannel(direction) {
         setLine2("Fail 01/82");
     }
 
-    const currentChannel = currentZone.channels[currentChannelIndex];
-
-    responsiveVoice.speak(`${currentChannel.name_announce}`, `US English Female`, {rate: .8});
+    if (currentCodeplug.isAnnounceZoneChannelTalkgroups === true && isResponsiveVoiceApiKeySet === true) {
+        const currentChannel = currentZone.channels[currentChannelIndex];
+        responsiveVoice.speak(`${currentChannel.name_announce}`, `US English Female`, {rate: .8});
+    }
 
     SendGroupAffiliationRemoval(currentTg);
 
@@ -964,11 +965,14 @@ function changeZone(direction) {
     }
 
     currentChannelIndex = 0;
-    const currentZone = currentCodeplug.zones[currentZoneIndex];
-    const currentChannel = currentZone.channels[currentChannelIndex];
 
-    responsiveVoice.speak(`${currentZone.name_announce}`, `US English Female`, {rate: .8});
-    responsiveVoice.speak(`${currentChannel.name_announce}`, `US English Female`, {rate: .8});
+    if (currentCodeplug.isAnnounceZoneChannelTalkgroups === true && isResponsiveVoiceApiKeySet === true) {
+        const currentZone = currentCodeplug.zones[currentZoneIndex];
+        const currentChannel = currentZone.channels[currentChannelIndex];
+        responsiveVoice.speak(`${currentZone.name_announce}`, `US English Female`, {rate: .8});
+        responsiveVoice.speak(`${currentChannel.name_announce}`, `US English Female`, {rate: .8});
+    }
+    
     SendGroupAffiliationRemoval(currentTg);
 
     updateDisplay();

--- a/client/ui/js/script.js
+++ b/client/ui/js/script.js
@@ -409,7 +409,7 @@ window.addEventListener('message', async function (event) {
             return;
         }
 
-        if (currentCodeplug.zones[currentZoneIndex].channels[currentChannelIndex].receiveOnly === true) {
+        if (currentCodeplug.zones[currentZoneIndex].channels[currentChannelIndex].isReceiveOnly === true) {
             console.debug("Cannot tx, rx only");
             bonk();
             return;

--- a/client/ui/js/script.js
+++ b/client/ui/js/script.js
@@ -919,7 +919,7 @@ function changeChannel(direction) {
 
     const currentChannel = currentZone.channels[currentChannelIndex];
 
-    // responsiveVoice.speak(`${currentChannel.name}`, `US English Female`, {rate: .8});
+    responsiveVoice.speak(`${currentChannel.name_announce}`, `US English Female`, {rate: .8});
 
     SendGroupAffiliationRemoval(currentTg);
 

--- a/client/ui/js/script.js
+++ b/client/ui/js/script.js
@@ -409,6 +409,12 @@ window.addEventListener('message', async function (event) {
             return;
         }
 
+        if (currentCodeplug.zones[currentZoneIndex].channels[currentChannelIndex].receiveOnly === true) {
+            console.debug("Cannot tx, rx only");
+            bonk();
+            return;
+        }
+
         if (isReceiving) {
             console.debug("Receiving, not txing");
             bonk();

--- a/codeplugs/codeplug.example.yml
+++ b/codeplugs/codeplug.example.yml
@@ -5,7 +5,6 @@ radioWide:
   serialNumber: "123ABC1234"
   model: "APX6000"
   inCarMode: "APX4500"
-  announceZoneChannelChanges: false # Make sure you add your own API key in the main config file before enabling this
 
 systems:
   - name: "System 1"

--- a/codeplugs/codeplug.example.yml
+++ b/codeplugs/codeplug.example.yml
@@ -5,6 +5,7 @@ radioWide:
   serialNumber: "123ABC1234"
   model: "APX6000"
   inCarMode: "APX4500"
+  announceZoneChannelChanges: false # Make sure you add your own API key in the main config file before enabling this
 
 systems:
   - name: "System 1"

--- a/codeplugs/codeplug.example.yml
+++ b/codeplugs/codeplug.example.yml
@@ -22,30 +22,44 @@ qcList:
     b: 500.9
 
 zones:
-  - name: "Zone 1"
+  - name: "Z1" # Displayed on the radio UI
+    name_announce: "Zone 1" # Announced when switching to this zone
     channels:
-      - name: "Channel 1"
+      - name: "Ch 1" # Displayed on the radio UI
+        name_announce: "Channel 1" # Announced when switching to this channel
         system: "System 1"
         tgid: "2001"
         scanList: List 1
-      - name: "Channel 2"
+        isReceiveOnly: false
+      - name: "Ch 2" # Displayed on the radio UI
+        name_announce: "Channel 2" # Announced when switching to this channel
         system: "System 1"
         tgid: "15002"
-      - name: "Channel 3"
+        isReceiveOnly: false
+      - name: "Ch 3" # Displayed on the radio UI
+        name_announce: "Channel 3" # Announced when switching to this channel
         system: "System 1"
         tgid: "15003"
+        isReceiveOnly: false
 
-  - name: "Zone 2"
+  - name: "Z2" # Displayed on the radio UI
+    name_announce: "Zone 2" # Announced when switching to this zone
     channels:
-      - name: "Channel A"
+      - name: "Ch A" # Displayed on the radio UI
+        name_announce: "Channel A" # Announced when switching to this channel
         system: "System 1"
         tgid: "16001"
-      - name: "Channel B"
+        isReceiveOnly: false
+      - name: "Ch B" # Displayed on the radio UI
+        name_announce: "Channel B" # Announced when switching to this channel
         system: "System 1"
         tgid: "16002"
-      - name: "Channel C"
+        isReceiveOnly: false
+      - name: "Ch C" # Displayed on the radio UI
+        name_announce: "Channel C" # Announced when switching to this channel
         system: "System 1"
         tgid: "16002"
+        isReceiveOnly: false
 
 scanLists:
   - name: List 1

--- a/codeplugs/codeplug.example.yml
+++ b/codeplugs/codeplug.example.yml
@@ -5,6 +5,7 @@ radioWide:
   serialNumber: "123ABC1234"
   model: "APX6000"
   inCarMode: "APX4500"
+  isAnnonceZoneChannelChanges: false
 
 systems:
   - name: "System 1"

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -2,3 +2,4 @@ siteBlips: true
 disableAnimations: false
 # Beep volume reduction factor. 0.0 is full volume, 1.0 is silent
 beepVolumeReduction: 0.6
+responsiveVoiceApiKey: "add your api key"

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -2,4 +2,3 @@ siteBlips: true
 disableAnimations: false
 # Beep volume reduction factor. 0.0 is full volume, 1.0 is silent
 beepVolumeReduction: 0.6
-responsveVoiceApiKey: "add your api key here"

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -2,5 +2,4 @@ siteBlips: true
 disableAnimations: false
 # Beep volume reduction factor. 0.0 is full volume, 1.0 is silent
 beepVolumeReduction: 0.6
-announceZoneChannelChanges: false
 responsveVoiceApiKey: "add your api key here"

--- a/configs/config.yml
+++ b/configs/config.yml
@@ -2,3 +2,5 @@ siteBlips: true
 disableAnimations: false
 # Beep volume reduction factor. 0.0 is full volume, 1.0 is silent
 beepVolumeReduction: 0.6
+announceZoneChannelChanges: false
+responsveVoiceApiKey: "add your api key here"


### PR DESCRIPTION
**_Receive Only Channels_**
- This allows channels in a codeplug to be configured as receive only which prevents radios using that codeplug from transmitting on that channel.

**_ Different Zone/Channel Announce Text vs. Display Text_**
- This allows zone and channel names to announce text that is different than what it displays. (Ex: Radio could display channel name "LawDisp" but announce "Law Dispatch" when switching to that channel)