### PR TITLE
Clamp radio container to viewport and add scaling origin

### DIFF
--- a/client/ui/js/ui.js
+++ b/client/ui/js/ui.js
@@ -1,166 +1,197 @@
 /*
-* WhackerLink - WhackerLinkFiveM
-*
-* This program is free software: you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation, either version 3 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program.  If not, see <http://www.gnu.org/licenses/>.
-*
-* Copyright (C) 2024 Caleb, K4PHP
-*
-*/
+ * WhackerLink - WhackerLinkFiveM
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Copyright (C) 2024 Caleb, K4PHP
+ *
+ */
 
 let isDragging = false;
 let isScaling = false;
 let scaleFactor = 1;
 
 const radioContainer = document.getElementById('radio-container');
+radioContainer.style.transformOrigin = 'right bottom';
+
+function clampRadioToViewport() {
+  const rect = radioContainer.getBoundingClientRect();
+  const maxRight = Math.max(window.innerWidth - rect.width, 0);
+  const maxBottom = Math.max(window.innerHeight - rect.height, 0);
+
+  const currentRight =
+    parseFloat(radioContainer.style.right) ||
+    Math.max(window.innerWidth - rect.right, 0);
+  const currentBottom =
+    parseFloat(radioContainer.style.bottom) ||
+    Math.max(window.innerHeight - rect.bottom, 0);
+
+  const clampedRight = Math.min(Math.max(currentRight, 0), maxRight);
+  const clampedBottom = Math.min(Math.max(currentBottom, 0), maxBottom);
+
+  radioContainer.style.right = `${clampedRight}px`;
+  radioContainer.style.bottom = `${clampedBottom}px`;
+  radioContainer.style.left = 'auto';
+  radioContainer.style.top = 'auto';
+  radioContainer.style.position = 'absolute';
+}
 
 function saveUIState() {
-    const uiState = {
-        right: radioContainer.style.right || null,
-        bottom: radioContainer.style.bottom || null,
-        position: radioContainer.style.position || null,
-        transform: `scale(${scaleFactor})` || null,
-        scale: scaleFactor
-    };
+  const uiState = {
+    right: radioContainer.style.right || null,
+    bottom: radioContainer.style.bottom || null,
+    position: radioContainer.style.position || null,
+    transform: `scale(${scaleFactor})` || null,
+    scale: scaleFactor,
+  };
 
-    fetch(`https://${GetParentResourceName()}/saveUIState`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ uiState, model: radioModel })
-    }).then(response => response.json())
-        .then(data => {
-            if (data.status !== 'success') {
-                console.error('Failed to save UI state');
-            }
-        }).catch(err => console.error('Error saving UI state:', err));
+  fetch(`https://${GetParentResourceName()}/saveUIState`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ uiState, model: radioModel }),
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      if (data.status !== 'success') {
+        console.error('Failed to save UI state');
+      }
+    })
+    .catch((err) => console.error('Error saving UI state:', err));
 }
 
 function loadUIState() {
-    fetch(`https://${GetParentResourceName()}/loadUIState`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: radioModel })
-    }).then(response => response.json())
-        .then(data => {
-            const uiState = data.uiState;
+  fetch(`https://${GetParentResourceName()}/loadUIState`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ model: radioModel }),
+  })
+    .then((response) => response.json())
+    .then((data) => {
+      const uiState = data.uiState;
 
-            if (uiState) {
-                if (uiState.right) radioContainer.style.right = uiState.right;
-                if (uiState.bottom) radioContainer.style.bottom = uiState.bottom;
-                if (uiState.position) radioContainer.style.position = uiState.position;
-                if (uiState.scale) scaleFactor = uiState.scale;
+      if (uiState) {
+        if (uiState.right) radioContainer.style.right = uiState.right;
+        if (uiState.bottom) radioContainer.style.bottom = uiState.bottom;
+        if (uiState.position) radioContainer.style.position = uiState.position;
+        if (uiState.scale) scaleFactor = uiState.scale;
 
-                if (uiState.transform) {
-                    const match = uiState.transform.match(/scale\(([\d.]+)\)/);
-                    if (match) {
-                        scaleFactor = parseFloat(match[1]);
-                        radioContainer.style.transform = uiState.transform;
-                    }
-                }
+        if (uiState.transform) {
+          const match = uiState.transform.match(/scale\(([\d.]+)\)/);
+          if (match) {
+            scaleFactor = parseFloat(match[1]);
+            radioContainer.style.transform = uiState.transform;
+          }
+        }
 
-                console.log("Used loaded UI state");
-            } else {
-                console.log("No UI state set");
-                radioContainer.style.right = null;
-                radioContainer.style.bottom = null;
-                radioContainer.style.left = 'auto';
-                radioContainer.style.top = 'auto';
-                radioContainer.style.transform = null;
-                radioContainer.style.position = null;
-                scaleFactor = 1;
-                resetUI();
-                loadRadioModelAssets(radioModel);
-            }
-        })
-        .catch(err => {
-            console.error('Failed to load UI state:', err);
-            resetUI();
-            loadRadioModelAssets(radioModel);
-        });
+        console.log('Used loaded UI state');
+      } else {
+        console.log('No UI state set');
+        radioContainer.style.right = null;
+        radioContainer.style.bottom = null;
+        radioContainer.style.left = 'auto';
+        radioContainer.style.top = 'auto';
+        radioContainer.style.transform = null;
+        radioContainer.style.position = null;
+        scaleFactor = 1;
+        resetUI();
+        loadRadioModelAssets(radioModel);
+      }
+    })
+    .catch((err) => {
+      console.error('Failed to load UI state:', err);
+      resetUI();
+      loadRadioModelAssets(radioModel);
+    });
 }
 
 function resetUI() {
-    radioContainer.style.right = null;
-    radioContainer.style.bottom = null;
-    radioContainer.style.left = 'auto';
-    radioContainer.style.top = 'auto';
-    radioContainer.style.transform = null;
-    radioContainer.style.position = null;
-    scaleFactor = 1;
+  radioContainer.style.right = null;
+  radioContainer.style.bottom = null;
+  radioContainer.style.left = 'auto';
+  radioContainer.style.top = 'auto';
+  radioContainer.style.transform = null;
+  radioContainer.style.position = null;
+  scaleFactor = 1;
 }
 
 radioContainer.addEventListener('mousedown', (e) => {
-    if (!isDragging) return;
+  if (!isDragging) return;
 
-    const rect = radioContainer.getBoundingClientRect();
-    const offsetX = e.clientX - rect.right + rect.width;
-    const offsetY = e.clientY - rect.bottom + rect.height;
+  const rect = radioContainer.getBoundingClientRect();
+  const offsetX = e.clientX - rect.right + rect.width;
+  const offsetY = e.clientY - rect.bottom + rect.height;
 
-    const onMouseMove = (e) => {
-        const newRight = window.innerWidth - e.clientX - offsetX;
-        const newBottom = window.innerHeight - e.clientY - offsetY;
-        radioContainer.style.right = `${Math.max(newRight, 0)}px`;
-        radioContainer.style.bottom = `${Math.max(newBottom, 0)}px`;
-        radioContainer.style.left = 'auto';
-        radioContainer.style.top = 'auto';
-        radioContainer.style.position = 'absolute';
-        saveUIState();
-    };
+  const onMouseMove = (e) => {
+    const newRight = window.innerWidth - e.clientX - offsetX;
+    const newBottom = window.innerHeight - e.clientY - offsetY;
+    radioContainer.style.right = `${newRight}px`;
+    radioContainer.style.bottom = `${newBottom}px`;
+    radioContainer.style.left = 'auto';
+    radioContainer.style.top = 'auto';
+    radioContainer.style.position = 'absolute';
+    clampRadioToViewport();
+    saveUIState();
+  };
 
-    const onMouseUp = () => {
-        document.removeEventListener('mousemove', onMouseMove);
-        document.removeEventListener('mouseup', onMouseUp);
-        saveUIState();
-    };
+  const onMouseUp = () => {
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    saveUIState();
+  };
 
-    document.addEventListener('mousemove', onMouseMove);
-    document.addEventListener('mouseup', onMouseUp);
+  document.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('mouseup', onMouseUp);
 });
 
 radioContainer.addEventListener('wheel', (e) => {
-    if (!isScaling) return;
+  if (!isScaling) return;
 
-    e.preventDefault();
-    scaleFactor += e.deltaY > 0 ? -0.05 : 0.05;
-    scaleFactor = Math.min(Math.max(scaleFactor, 0.5), 2);
-    radioContainer.style.transform = `scale(${scaleFactor})`;
+  e.preventDefault();
+  scaleFactor += e.deltaY > 0 ? -0.05 : 0.05;
+  scaleFactor = Math.min(Math.max(scaleFactor, 0.5), 2);
+  radioContainer.style.transform = `scale(${scaleFactor})`;
+  clampRadioToViewport();
 
-    saveUIState();
+  saveUIState();
 });
 
 document.getElementById('reset-position').addEventListener('click', () => {
-    resetUI();
-    saveUIState();
+  resetUI();
+  saveUIState();
 });
 
 document.getElementById('drag-toggle').addEventListener('click', () => {
-    isDragging = !isDragging;
-    document.getElementById('drag-toggle').textContent =
-        isDragging ? 'Disable Drag' : 'Enable Drag';
+  isDragging = !isDragging;
+  document.getElementById('drag-toggle').textContent = isDragging
+    ? 'Disable Drag'
+    : 'Enable Drag';
 });
 
 document.getElementById('scale-toggle').addEventListener('click', () => {
-    isScaling = !isScaling;
-    document.getElementById('scale-toggle').textContent =
-        isScaling ? 'Disable Scale' : 'Enable Scale';
+  isScaling = !isScaling;
+  document.getElementById('scale-toggle').textContent = isScaling
+    ? 'Disable Scale'
+    : 'Enable Scale';
 });
 
 radioContainer.addEventListener('focus', () => {
-    radioContainer.classList.add('focus-visible');
+  radioContainer.classList.add('focus-visible');
 });
 
 radioContainer.addEventListener('blur', () => {
-    radioContainer.classList.remove('focus-visible');
+  radioContainer.classList.remove('focus-visible');
 });
 
 document.addEventListener('DOMContentLoaded', loadUIState);
+window.addEventListener('resize', clampRadioToViewport);

--- a/client/ui/js/ui.js
+++ b/client/ui/js/ui.js
@@ -1,22 +1,22 @@
 /*
- * WhackerLink - WhackerLinkFiveM
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Copyright (C) 2024 Caleb, K4PHP
- *
- */
+* WhackerLink - WhackerLinkFiveM
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* Copyright (C) 2024 Caleb, K4PHP
+*
+*/
 
 let isDragging = false;
 let isScaling = false;
@@ -26,171 +26,169 @@ const radioContainer = document.getElementById('radio-container');
 radioContainer.style.transformOrigin = 'right bottom';
 
 function clampRadioToViewport() {
-  const rect = radioContainer.getBoundingClientRect();
-  const maxRight = Math.max(window.innerWidth - rect.width, 0);
-  const maxBottom = Math.max(window.innerHeight - rect.height, 0);
+    const rect = radioContainer.getBoundingClientRect();
+    const maxRight = Math.max(window.innerWidth - rect.width, 0);
+    const maxBottom = Math.max(window.innerHeight - rect.height, 0);
 
-  const currentRight =
-    parseFloat(radioContainer.style.right) ||
-    Math.max(window.innerWidth - rect.right, 0);
-  const currentBottom =
-    parseFloat(radioContainer.style.bottom) ||
-    Math.max(window.innerHeight - rect.bottom, 0);
+    const currentRight =
+        parseFloat(radioContainer.style.right) ||
+        Math.max(window.innerWidth - rect.right, 0);
+    const currentBottom =
+        parseFloat(radioContainer.style.bottom) ||
+        Math.max(window.innerHeight - rect.bottom, 0);
 
-  const clampedRight = Math.min(Math.max(currentRight, 0), maxRight);
-  const clampedBottom = Math.min(Math.max(currentBottom, 0), maxBottom);
+    const clampedRight = Math.min(Math.max(currentRight, 0), maxRight);
+    const clampedBottom = Math.min(Math.max(currentBottom, 0), maxBottom);
 
-  radioContainer.style.right = `${clampedRight}px`;
-  radioContainer.style.bottom = `${clampedBottom}px`;
-  radioContainer.style.left = 'auto';
-  radioContainer.style.top = 'auto';
-  radioContainer.style.position = 'absolute';
-}
-
-function saveUIState() {
-  const uiState = {
-    right: radioContainer.style.right || null,
-    bottom: radioContainer.style.bottom || null,
-    position: radioContainer.style.position || null,
-    transform: `scale(${scaleFactor})` || null,
-    scale: scaleFactor,
-  };
-
-  fetch(`https://${GetParentResourceName()}/saveUIState`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ uiState, model: radioModel }),
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      if (data.status !== 'success') {
-        console.error('Failed to save UI state');
-      }
-    })
-    .catch((err) => console.error('Error saving UI state:', err));
-}
-
-function loadUIState() {
-  fetch(`https://${GetParentResourceName()}/loadUIState`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ model: radioModel }),
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      const uiState = data.uiState;
-
-      if (uiState) {
-        if (uiState.right) radioContainer.style.right = uiState.right;
-        if (uiState.bottom) radioContainer.style.bottom = uiState.bottom;
-        if (uiState.position) radioContainer.style.position = uiState.position;
-        if (uiState.scale) scaleFactor = uiState.scale;
-
-        if (uiState.transform) {
-          const match = uiState.transform.match(/scale\(([\d.]+)\)/);
-          if (match) {
-            scaleFactor = parseFloat(match[1]);
-            radioContainer.style.transform = uiState.transform;
-          }
-        }
-
-        console.log('Used loaded UI state');
-      } else {
-        console.log('No UI state set');
-        radioContainer.style.right = null;
-        radioContainer.style.bottom = null;
-        radioContainer.style.left = 'auto';
-        radioContainer.style.top = 'auto';
-        radioContainer.style.transform = null;
-        radioContainer.style.position = null;
-        scaleFactor = 1;
-        resetUI();
-        loadRadioModelAssets(radioModel);
-      }
-    })
-    .catch((err) => {
-      console.error('Failed to load UI state:', err);
-      resetUI();
-      loadRadioModelAssets(radioModel);
-    });
-}
-
-function resetUI() {
-  radioContainer.style.right = null;
-  radioContainer.style.bottom = null;
-  radioContainer.style.left = 'auto';
-  radioContainer.style.top = 'auto';
-  radioContainer.style.transform = null;
-  radioContainer.style.position = null;
-  scaleFactor = 1;
-}
-
-radioContainer.addEventListener('mousedown', (e) => {
-  if (!isDragging) return;
-
-  const rect = radioContainer.getBoundingClientRect();
-  const offsetX = e.clientX - rect.right + rect.width;
-  const offsetY = e.clientY - rect.bottom + rect.height;
-
-  const onMouseMove = (e) => {
-    const newRight = window.innerWidth - e.clientX - offsetX;
-    const newBottom = window.innerHeight - e.clientY - offsetY;
-    radioContainer.style.right = `${newRight}px`;
-    radioContainer.style.bottom = `${newBottom}px`;
+    radioContainer.style.right = `${clampedRight}px`;
+    radioContainer.style.bottom = `${clampedBottom}px`;
     radioContainer.style.left = 'auto';
     radioContainer.style.top = 'auto';
     radioContainer.style.position = 'absolute';
-    clampRadioToViewport();
-    saveUIState();
-  };
+}
 
-  const onMouseUp = () => {
-    document.removeEventListener('mousemove', onMouseMove);
-    document.removeEventListener('mouseup', onMouseUp);
-    saveUIState();
-  };
+function saveUIState() {
+    const uiState = {
+        right: radioContainer.style.right || null,
+        bottom: radioContainer.style.bottom || null,
+        position: radioContainer.style.position || null,
+        transform: `scale(${scaleFactor})` || null,
+        scale: scaleFactor,
+    };
 
-  document.addEventListener('mousemove', onMouseMove);
-  document.addEventListener('mouseup', onMouseUp);
+    fetch(`https://${GetParentResourceName()}/saveUIState`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uiState, model: radioModel }),
+    })
+        .then((response) => response.json())
+        .then((data) => {
+            if (data.status !== 'success') {
+                console.error('Failed to save UI state');
+            }
+        })
+        .catch((err) => console.error('Error saving UI state:', err));
+}
+
+function loadUIState() {
+    fetch(`https://${GetParentResourceName()}/loadUIState`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: radioModel }),
+    })
+        .then((response) => response.json())
+        .then((data) => {
+            const uiState = data.uiState;
+
+            if (uiState) {
+                if (uiState.right) radioContainer.style.right = uiState.right;
+                if (uiState.bottom)
+                    radioContainer.style.bottom = uiState.bottom;
+                if (uiState.position)
+                    radioContainer.style.position = uiState.position;
+                if (uiState.scale) scaleFactor = uiState.scale;
+
+                if (uiState.transform) {
+                    const match = uiState.transform.match(/scale\(([\d.]+)\)/);
+                    if (match) {
+                        scaleFactor = parseFloat(match[1]);
+                        radioContainer.style.transform = uiState.transform;
+                    }
+                }
+
+                console.log('Used loaded UI state');
+            } else {
+                console.log('No UI state set');
+                radioContainer.style.right = null;
+                radioContainer.style.bottom = null;
+                radioContainer.style.left = 'auto';
+                radioContainer.style.top = 'auto';
+                radioContainer.style.transform = null;
+                radioContainer.style.position = null;
+                scaleFactor = 1;
+                resetUI();
+                loadRadioModelAssets(radioModel);
+            }
+        })
+        .catch((err) => {
+            console.error('Failed to load UI state:', err);
+            resetUI();
+            loadRadioModelAssets(radioModel);
+        });
+}
+
+function resetUI() {
+    radioContainer.style.right = null;
+    radioContainer.style.bottom = null;
+    radioContainer.style.left = 'auto';
+    radioContainer.style.top = 'auto';
+    radioContainer.style.transform = null;
+    radioContainer.style.position = null;
+    scaleFactor = 1;
+}
+
+radioContainer.addEventListener('mousedown', (e) => {
+    if (!isDragging) return;
+
+    const rect = radioContainer.getBoundingClientRect();
+    const offsetX = e.clientX - rect.right + rect.width;
+    const offsetY = e.clientY - rect.bottom + rect.height;
+
+    const onMouseMove = (e) => {
+        const newRight = window.innerWidth - e.clientX - offsetX;
+        const newBottom = window.innerHeight - e.clientY - offsetY;
+        radioContainer.style.right = `${newRight}px`;
+        radioContainer.style.bottom = `${newBottom}px`;
+        radioContainer.style.left = 'auto';
+        radioContainer.style.top = 'auto';
+        radioContainer.style.position = 'absolute';
+        clampRadioToViewport();
+        saveUIState();
+    };
+
+    const onMouseUp = () => {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        saveUIState();
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
 });
 
 radioContainer.addEventListener('wheel', (e) => {
-  if (!isScaling) return;
+    if (!isScaling) return;
 
-  e.preventDefault();
-  scaleFactor += e.deltaY > 0 ? -0.05 : 0.05;
-  scaleFactor = Math.min(Math.max(scaleFactor, 0.5), 2);
-  radioContainer.style.transform = `scale(${scaleFactor})`;
-  clampRadioToViewport();
+    e.preventDefault();
+    scaleFactor += e.deltaY > 0 ? -0.05 : 0.05;
+    scaleFactor = Math.min(Math.max(scaleFactor, 0.5), 2);
+    radioContainer.style.transform = `scale(${scaleFactor})`;
+    clampRadioToViewport();
 
-  saveUIState();
+    saveUIState();
 });
 
 document.getElementById('reset-position').addEventListener('click', () => {
-  resetUI();
-  saveUIState();
+    resetUI();
+    saveUIState();
 });
 
 document.getElementById('drag-toggle').addEventListener('click', () => {
-  isDragging = !isDragging;
-  document.getElementById('drag-toggle').textContent = isDragging
-    ? 'Disable Drag'
-    : 'Enable Drag';
+    isDragging = !isDragging;
+    document.getElementById('drag-toggle').textContent = isDragging ? 'Disable Drag' : 'Enable Drag';
 });
 
 document.getElementById('scale-toggle').addEventListener('click', () => {
-  isScaling = !isScaling;
-  document.getElementById('scale-toggle').textContent = isScaling
-    ? 'Disable Scale'
-    : 'Enable Scale';
+    isScaling = !isScaling;
+    document.getElementById('scale-toggle').textContent = isScaling ? 'Disable Scale' : 'Enable Scale';
 });
 
 radioContainer.addEventListener('focus', () => {
-  radioContainer.classList.add('focus-visible');
+    radioContainer.classList.add('focus-visible');
 });
 
 radioContainer.addEventListener('blur', () => {
-  radioContainer.classList.remove('focus-visible');
+    radioContainer.classList.remove('focus-visible');
 });
 
 document.addEventListener('DOMContentLoaded', loadUIState);

--- a/client/ui/js/ui.js
+++ b/client/ui/js/ui.js
@@ -53,39 +53,34 @@ function saveUIState() {
         bottom: radioContainer.style.bottom || null,
         position: radioContainer.style.position || null,
         transform: `scale(${scaleFactor})` || null,
-        scale: scaleFactor,
+        scale: scaleFactor
     };
 
     fetch(`https://${GetParentResourceName()}/saveUIState`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ uiState, model: radioModel }),
-    })
-        .then((response) => response.json())
-        .then((data) => {
+        body: JSON.stringify({ uiState, model: radioModel })
+    }).then(response => response.json())
+        .then(data => {
             if (data.status !== 'success') {
                 console.error('Failed to save UI state');
             }
-        })
-        .catch((err) => console.error('Error saving UI state:', err));
+        }).catch(err => console.error('Error saving UI state:', err));
 }
 
 function loadUIState() {
     fetch(`https://${GetParentResourceName()}/loadUIState`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ model: radioModel }),
-    })
-        .then((response) => response.json())
-        .then((data) => {
+        body: JSON.stringify({ model: radioModel })
+    }).then(response => response.json())
+        .then(data => {
             const uiState = data.uiState;
 
             if (uiState) {
                 if (uiState.right) radioContainer.style.right = uiState.right;
-                if (uiState.bottom)
-                    radioContainer.style.bottom = uiState.bottom;
-                if (uiState.position)
-                    radioContainer.style.position = uiState.position;
+                if (uiState.bottom) radioContainer.style.bottom = uiState.bottom;
+                if (uiState.position) radioContainer.style.position = uiState.position;
                 if (uiState.scale) scaleFactor = uiState.scale;
 
                 if (uiState.transform) {
@@ -96,9 +91,9 @@ function loadUIState() {
                     }
                 }
 
-                console.log('Used loaded UI state');
+                console.log("Used loaded UI state");
             } else {
-                console.log('No UI state set');
+                console.log("No UI state set");
                 radioContainer.style.right = null;
                 radioContainer.style.bottom = null;
                 radioContainer.style.left = 'auto';
@@ -110,7 +105,7 @@ function loadUIState() {
                 loadRadioModelAssets(radioModel);
             }
         })
-        .catch((err) => {
+        .catch(err => {
             console.error('Failed to load UI state:', err);
             resetUI();
             loadRadioModelAssets(radioModel);
@@ -175,12 +170,14 @@ document.getElementById('reset-position').addEventListener('click', () => {
 
 document.getElementById('drag-toggle').addEventListener('click', () => {
     isDragging = !isDragging;
-    document.getElementById('drag-toggle').textContent = isDragging ? 'Disable Drag' : 'Enable Drag';
+    document.getElementById('drag-toggle').textContent =
+        isDragging ? 'Disable Drag' : 'Enable Drag';
 });
 
 document.getElementById('scale-toggle').addEventListener('click', () => {
     isScaling = !isScaling;
-    document.getElementById('scale-toggle').textContent = isScaling ? 'Disable Scale' : 'Enable Scale';
+    document.getElementById('scale-toggle').textContent =
+        isScaling ? 'Disable Scale' : 'Enable Scale';
 });
 
 radioContainer.addEventListener('focus', () => {

--- a/client/ui/style.css
+++ b/client/ui/style.css
@@ -1,97 +1,103 @@
 #radio-container {
-    position: fixed;
-    bottom: 5px;
-    right: 10px;
-    display: inline-block;
+  position: fixed;
+  bottom: 5px;
+  right: 10px;
+  display: inline-block;
 }
 
 #radio-image {
-    display: block;
-    width: 300px;
-    height: auto;
-    position: relative;
+  display: block;
+  width: 300px;
+  height: auto;
+  position: relative;
 }
 
-#channel-up, #zone-up {
-    position: absolute;
-    transform: translateX(-50%);
-    top: 91%;
-    z-index: 1;
-    display: block;
-    margin: 10px auto;
-    padding: 7px;
-    background-color: transparent;
-    color: transparent;
-    border: none;
-    cursor: pointer;
+#channel-up,
+#zone-up {
+  position: absolute;
+  transform: translateX(-50%);
+  top: 91%;
+  z-index: 1;
+  display: block;
+  margin: 10px auto;
+  padding: 7px;
+  background-color: transparent;
+  color: transparent;
+  border: none;
+  cursor: pointer;
 }
 
 #channel-up {
-    left: 63%;
+  left: 63%;
 }
 
 #zone-up {
-    left: 37%;
+  left: 37%;
 }
 
-#line1, #line2, #line3, #softText1, #softText2, #softText3 {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 1;
-    color: black;
-    font-size: 17px;
-    font-family: Helvetica, serif;
-    font-weight: bold;
-    text-align: center;
-    width: 90%;
+#line1,
+#line2,
+#line3,
+#softText1,
+#softText2,
+#softText3 {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+  color: black;
+  font-size: 17px;
+  font-family: Helvetica, serif;
+  font-weight: bold;
+  text-align: center;
+  width: 90%;
 }
 
 #softText1 {
-    font-size: 12px;
-    top: 87%;
-    left: 36%;
+  font-size: 12px;
+  top: 87%;
+  left: 36%;
 }
 
 #softText2 {
-    font-size: 12px;
-    top: 87%;
-    left: 36%;
+  font-size: 12px;
+  top: 87%;
+  left: 36%;
 }
 
 #softText3 {
-    font-size: 12px;
-    top: 87%;
-    left: 63.5%;
+  font-size: 12px;
+  top: 87%;
+  left: 63.5%;
 }
 
 #line1 {
-    top: 73%;
+  top: 73%;
 }
 
 #line2 {
-    top: 77%;
-    font-size: 15px;
+  top: 77%;
+  font-size: 15px;
 }
 
 #line3 {
-    top: 81.5%;
-    font-size: 14px;
+  top: 81.5%;
+  font-size: 14px;
 }
 
 #startup-message {
-    background-color: white;
-    padding: 20px;
-    border-radius: 10px;
-    text-align: center;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-    display: none;
+  background-color: white;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  display: none;
 }
 
 #startup-message h1 {
-    margin: 0 0 10px;
+  margin: 0 0 10px;
 }
 
 #startup-message p {
-    margin: 5px 0;
+  margin: 5px 0;
 }

--- a/client/ui/style.css
+++ b/client/ui/style.css
@@ -1,38 +1,39 @@
 #radio-container {
-  position: fixed;
-  bottom: 5px;
-  right: 10px;
-  display: inline-block;
+    position: fixed;
+    bottom: 5px;
+    right: 10px;
+    display: inline-block;
+    transform-origin: right bottom;
 }
 
 #radio-image {
-  display: block;
-  width: 300px;
-  height: auto;
-  position: relative;
+    display: block;
+    width: 300px;
+    height: auto;
+    position: relative;
 }
 
 #channel-up,
 #zone-up {
-  position: absolute;
-  transform: translateX(-50%);
-  top: 91%;
-  z-index: 1;
-  display: block;
-  margin: 10px auto;
-  padding: 7px;
-  background-color: transparent;
-  color: transparent;
-  border: none;
-  cursor: pointer;
+    position: absolute;
+    transform: translateX(-50%);
+    top: 91%;
+    z-index: 1;
+    display: block;
+    margin: 10px auto;
+    padding: 7px;
+    background-color: transparent;
+    color: transparent;
+    border: none;
+    cursor: pointer;
 }
 
 #channel-up {
-  left: 63%;
+    left: 63%;
 }
 
 #zone-up {
-  left: 37%;
+    left: 37%;
 }
 
 #line1,
@@ -41,63 +42,63 @@
 #softText1,
 #softText2,
 #softText3 {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1;
-  color: black;
-  font-size: 17px;
-  font-family: Helvetica, serif;
-  font-weight: bold;
-  text-align: center;
-  width: 90%;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1;
+    color: black;
+    font-size: 17px;
+    font-family: Helvetica, serif;
+    font-weight: bold;
+    text-align: center;
+    width: 90%;
 }
 
 #softText1 {
-  font-size: 12px;
-  top: 87%;
-  left: 36%;
+    font-size: 12px;
+    top: 87%;
+    left: 36%;
 }
 
 #softText2 {
-  font-size: 12px;
-  top: 87%;
-  left: 36%;
+    font-size: 12px;
+    top: 87%;
+    left: 36%;
 }
 
 #softText3 {
-  font-size: 12px;
-  top: 87%;
-  left: 63.5%;
+    font-size: 12px;
+    top: 87%;
+    left: 63.5%;
 }
 
 #line1 {
-  top: 73%;
+    top: 73%;
 }
 
 #line2 {
-  top: 77%;
-  font-size: 15px;
+    top: 77%;
+    font-size: 15px;
 }
 
 #line3 {
-  top: 81.5%;
-  font-size: 14px;
+    top: 81.5%;
+    font-size: 14px;
 }
 
 #startup-message {
-  background-color: white;
-  padding: 20px;
-  border-radius: 10px;
-  text-align: center;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-  display: none;
+    background-color: white;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    display: none;
 }
 
 #startup-message h1 {
-  margin: 0 0 10px;
+    margin: 0 0 10px;
 }
 
 #startup-message p {
-  margin: 5px 0;
+    margin: 5px 0;
 }

--- a/client/ui/style/style.css
+++ b/client/ui/style/style.css
@@ -1,39 +1,39 @@
 #radio-container {
-  position: fixed;
-  bottom: 5px;
-  right: 10px;
-  display: inline-block;
-  transform-origin: right bottom;
+    position: fixed;
+    bottom: 5px;
+    right: 10px;
+    display: inline-block;
+    transform-origin: right bottom;
 }
 
 #radio-image {
-  display: block;
-  width: 300px;
-  height: auto;
-  position: relative;
+    display: block;
+    width: 300px;
+    height: auto;
+    position: relative;
 }
 
 #channel-up,
 #zone-up {
-  position: absolute;
-  transform: translateX(-50%);
-  top: 91%;
-  z-index: 1;
-  display: block;
-  margin: 10px auto;
-  padding: 7px;
-  background-color: transparent;
-  color: transparent;
-  border: none;
-  cursor: pointer;
+    position: absolute;
+    transform: translateX(-50%);
+    top: 91%;
+    z-index: 1;
+    display: block;
+    margin: 10px auto;
+    padding: 7px;
+    background-color: transparent;
+    color: transparent;
+    border: none;
+    cursor: pointer;
 }
 
 #channel-up {
-  left: 63%;
+    left: 63%;
 }
 
 #zone-up {
-  left: 37%;
+    left: 37%;
 }
 
 #line1,
@@ -42,63 +42,63 @@
 #softText1,
 #softText2,
 #softText3 {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 1;
-  color: black;
-  font-size: 17px;
-  font-family: Helvetica, serif;
-  font-weight: bold;
-  text-align: center;
-  width: 90%;
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1;
+    color: black;
+    font-size: 17px;
+    font-family: Helvetica, serif;
+    font-weight: bold;
+    text-align: center;
+    width: 90%;
 }
 
 #softText1 {
-  font-size: 12px;
-  top: 87%;
-  left: 36%;
+    font-size: 12px;
+    top: 87%;
+    left: 36%;
 }
 
 #softText2 {
-  font-size: 12px;
-  top: 87%;
-  left: 36%;
+    font-size: 12px;
+    top: 87%;
+    left: 36%;
 }
 
 #softText3 {
-  font-size: 12px;
-  top: 87%;
-  left: 63.5%;
+    font-size: 12px;
+    top: 87%;
+    left: 63.5%;
 }
 
 #line1 {
-  top: 73%;
+    top: 73%;
 }
 
 #line2 {
-  top: 77%;
-  font-size: 15px;
+    top: 77%;
+    font-size: 15px;
 }
 
 #line3 {
-  top: 81.5%;
-  font-size: 14px;
+    top: 81.5%;
+    font-size: 14px;
 }
 
 #startup-message {
-  background-color: white;
-  padding: 20px;
-  border-radius: 10px;
-  text-align: center;
-  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-  display: none;
+    background-color: white;
+    padding: 20px;
+    border-radius: 10px;
+    text-align: center;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+    display: none;
 }
 
 #startup-message h1 {
-  margin: 0 0 10px;
+    margin: 0 0 10px;
 }
 
 #startup-message p {
-  margin: 5px 0;
+    margin: 5px 0;
 }

--- a/client/ui/style/style.css
+++ b/client/ui/style/style.css
@@ -1,97 +1,104 @@
 #radio-container {
-    position: fixed;
-    bottom: 5px;
-    right: 10px;
-    display: inline-block;
+  position: fixed;
+  bottom: 5px;
+  right: 10px;
+  display: inline-block;
+  transform-origin: right bottom;
 }
 
 #radio-image {
-    display: block;
-    width: 300px;
-    height: auto;
-    position: relative;
+  display: block;
+  width: 300px;
+  height: auto;
+  position: relative;
 }
 
-#channel-up, #zone-up {
-    position: absolute;
-    transform: translateX(-50%);
-    top: 91%;
-    z-index: 1;
-    display: block;
-    margin: 10px auto;
-    padding: 7px;
-    background-color: transparent;
-    color: transparent;
-    border: none;
-    cursor: pointer;
+#channel-up,
+#zone-up {
+  position: absolute;
+  transform: translateX(-50%);
+  top: 91%;
+  z-index: 1;
+  display: block;
+  margin: 10px auto;
+  padding: 7px;
+  background-color: transparent;
+  color: transparent;
+  border: none;
+  cursor: pointer;
 }
 
 #channel-up {
-    left: 63%;
+  left: 63%;
 }
 
 #zone-up {
-    left: 37%;
+  left: 37%;
 }
 
-#line1, #line2, #line3, #softText1, #softText2, #softText3 {
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 1;
-    color: black;
-    font-size: 17px;
-    font-family: Helvetica, serif;
-    font-weight: bold;
-    text-align: center;
-    width: 90%;
+#line1,
+#line2,
+#line3,
+#softText1,
+#softText2,
+#softText3 {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1;
+  color: black;
+  font-size: 17px;
+  font-family: Helvetica, serif;
+  font-weight: bold;
+  text-align: center;
+  width: 90%;
 }
 
 #softText1 {
-    font-size: 12px;
-    top: 87%;
-    left: 36%;
+  font-size: 12px;
+  top: 87%;
+  left: 36%;
 }
 
 #softText2 {
-    font-size: 12px;
-    top: 87%;
-    left: 36%;
+  font-size: 12px;
+  top: 87%;
+  left: 36%;
 }
 
 #softText3 {
-    font-size: 12px;
-    top: 87%;
-    left: 63.5%;
+  font-size: 12px;
+  top: 87%;
+  left: 63.5%;
 }
 
 #line1 {
-    top: 73%;
+  top: 73%;
 }
 
 #line2 {
-    top: 77%;
-    font-size: 15px;
+  top: 77%;
+  font-size: 15px;
 }
 
 #line3 {
-    top: 81.5%;
-    font-size: 14px;
+  top: 81.5%;
+  font-size: 14px;
 }
 
 #startup-message {
-    background-color: white;
-    padding: 20px;
-    border-radius: 10px;
-    text-align: center;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
-    display: none;
+  background-color: white;
+  padding: 20px;
+  border-radius: 10px;
+  text-align: center;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.5);
+  display: none;
 }
 
 #startup-message h1 {
-    margin: 0 0 10px;
+  margin: 0 0 10px;
 }
 
 #startup-message p {
-    margin: 5px 0;
+  margin: 5px 0;
 }


### PR DESCRIPTION
- Added a function to clamp the radio container to the viewport.
- Users can now move the radio container directly to any side of the viewport even when scaled down. And when scaled up the radio will stay in the viewport, instead of having cut off when moving to the end of the viewport.
- Added scale origin to the radio container.
- Unfortunately my code formatter made this seem like more changes than it is lol.

Tested on 2560 x 1440. Shouldn't be an issue for other resolutions.